### PR TITLE
배차 요청 도메인 모델 구현

### DIFF
--- a/core/core-api/src/main/java/com/giwankim/taxiservice/core/api/config/AsyncConfig.java
+++ b/core/core-api/src/main/java/com/giwankim/taxiservice/core/api/config/AsyncConfig.java
@@ -1,0 +1,29 @@
+package com.giwankim.taxiservice.core.api.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+  @Override
+  public Executor getAsyncExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(10);
+    executor.setMaxPoolSize(10);
+    executor.setQueueCapacity(10_000);
+    executor.setWaitForTasksToCompleteOnShutdown(true);
+    executor.setAwaitTerminationSeconds(10);
+    executor.initialize();
+    return executor;
+  }
+
+  @Override
+  public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+    return new AsyncExceptionHandler();
+  }
+}

--- a/core/core-api/src/main/java/com/giwankim/taxiservice/core/api/config/AsyncExceptionHandler.java
+++ b/core/core-api/src/main/java/com/giwankim/taxiservice/core/api/config/AsyncExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.giwankim.taxiservice.core.api.config;
+
+import com.giwankim.taxiservice.core.api.support.error.CoreApiException;
+import java.lang.reflect.Method;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+
+public class AsyncExceptionHandler implements AsyncUncaughtExceptionHandler {
+  private final Logger logger = LoggerFactory.getLogger(getClass());
+
+  @Override
+  public void handleUncaughtException(Throwable e, Method method, Object... params) {
+    if (e instanceof CoreApiException cae) {
+      switch (cae.getErrorType().getLogLevel()) {
+        case ERROR -> logger.error("CoreApiException : {}", cae.getMessage(), cae);
+        case WARN -> logger.warn("CoreApiException : {}", cae.getMessage(), cae);
+        default -> logger.info("CoreApiException : {}", cae.getMessage(), cae);
+      }
+    } else {
+      logger.error("Exception : {}", e.getMessage(), e);
+    }
+  }
+}

--- a/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/application/port/in/RequestPickupCommand.java
+++ b/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/application/port/in/RequestPickupCommand.java
@@ -2,7 +2,12 @@ package com.giwankim.taxiservice.core.domain.application.port.in;
 
 import com.giwankim.taxiservice.core.domain.domain.Location;
 import com.giwankim.taxiservice.core.domain.domain.Passenger;
+import com.giwankim.taxiservice.core.domain.domain.PickupRequest;
 import com.giwankim.taxiservice.core.domain.domain.TaxiType;
 
 public record RequestPickupCommand(
-    Passenger passenger, Location pickup, Location dropoff, TaxiType taxiType) {}
+    Passenger passenger, Location pickup, Location dropoff, TaxiType taxiType) {
+  public PickupRequest toPickupRequest() {
+    return new PickupRequest(passenger, pickup, dropoff, taxiType);
+  }
+}

--- a/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/application/port/in/RequestPickupCommand.java
+++ b/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/application/port/in/RequestPickupCommand.java
@@ -1,0 +1,8 @@
+package com.giwankim.taxiservice.core.domain.application.port.in;
+
+import com.giwankim.taxiservice.core.domain.domain.Location;
+import com.giwankim.taxiservice.core.domain.domain.Passenger;
+import com.giwankim.taxiservice.core.domain.domain.TaxiType;
+
+public record RequestPickupCommand(
+    Passenger passenger, Location pickup, Location dropoff, TaxiType taxiType) {}

--- a/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/application/port/in/RequestPickupUseCase.java
+++ b/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/application/port/in/RequestPickupUseCase.java
@@ -1,0 +1,7 @@
+package com.giwankim.taxiservice.core.domain.application.port.in;
+
+import com.giwankim.taxiservice.core.domain.domain.PickupRequest;
+
+public interface RequestPickupUseCase {
+  PickupRequest requestPickup(RequestPickupCommand command);
+}

--- a/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/application/port/out/DriverLock.java
+++ b/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/application/port/out/DriverLock.java
@@ -1,0 +1,9 @@
+package com.giwankim.taxiservice.core.domain.application.port.out;
+
+import com.giwankim.taxiservice.core.domain.domain.Driver;
+
+public interface DriverLock {
+  void lockDriver(Driver.DriverId driverId);
+
+  void releaseDriver(Driver.DriverId driverId);
+}

--- a/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/application/port/out/LoadDriversPort.java
+++ b/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/application/port/out/LoadDriversPort.java
@@ -1,0 +1,9 @@
+package com.giwankim.taxiservice.core.domain.application.port.out;
+
+import com.giwankim.taxiservice.core.domain.domain.Driver;
+import com.giwankim.taxiservice.core.domain.domain.Location;
+import java.util.List;
+
+public interface LoadDriversPort {
+  List<Driver> loadDriversNear(Location location, double distance);
+}

--- a/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/application/port/out/LoadPickupRequestPort.java
+++ b/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/application/port/out/LoadPickupRequestPort.java
@@ -1,0 +1,7 @@
+package com.giwankim.taxiservice.core.domain.application.port.out;
+
+import com.giwankim.taxiservice.core.domain.domain.PickupRequest;
+
+public interface LoadPickupRequestPort {
+  PickupRequest loadPickupRequest(PickupRequest.RequestId id);
+}

--- a/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/application/port/out/SearchLocationPort.java
+++ b/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/application/port/out/SearchLocationPort.java
@@ -4,6 +4,5 @@ import com.giwankim.taxiservice.core.domain.domain.Location;
 import java.util.List;
 
 public interface SearchLocationPort {
-
   List<Location> searchLocations(String keyword, int page, int size);
 }

--- a/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/application/port/out/StorePickupRequestPort.java
+++ b/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/application/port/out/StorePickupRequestPort.java
@@ -3,5 +3,5 @@ package com.giwankim.taxiservice.core.domain.application.port.out;
 import com.giwankim.taxiservice.core.domain.domain.PickupRequest;
 
 public interface StorePickupRequestPort {
-  String storePickupRequest(PickupRequest pickupRequest);
+  PickupRequest storePickupRequest(PickupRequest pickupRequest);
 }

--- a/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/application/port/out/StorePickupRequestPort.java
+++ b/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/application/port/out/StorePickupRequestPort.java
@@ -1,0 +1,7 @@
+package com.giwankim.taxiservice.core.domain.application.port.out;
+
+import com.giwankim.taxiservice.core.domain.domain.PickupRequest;
+
+public interface StorePickupRequestPort {
+  String storePickupRequest(PickupRequest pickupRequest);
+}

--- a/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/application/service/PickupRequestSubmittedEvent.java
+++ b/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/application/service/PickupRequestSubmittedEvent.java
@@ -1,0 +1,5 @@
+package com.giwankim.taxiservice.core.domain.application.service;
+
+import com.giwankim.taxiservice.core.domain.domain.PickupRequest;
+
+record PickupRequestSubmittedEvent(PickupRequest pickupRequest) {}

--- a/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/application/service/RequestPickupService.java
+++ b/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/application/service/RequestPickupService.java
@@ -1,0 +1,24 @@
+package com.giwankim.taxiservice.core.domain.application.service;
+
+import com.giwankim.taxiservice.core.domain.application.port.in.RequestPickupCommand;
+import com.giwankim.taxiservice.core.domain.application.port.in.RequestPickupUseCase;
+import com.giwankim.taxiservice.core.domain.application.port.out.StorePickupRequestPort;
+import com.giwankim.taxiservice.core.domain.domain.PickupRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RequestPickupService implements RequestPickupUseCase {
+  private final StorePickupRequestPort storePickupRequestPort;
+  private final ApplicationEventPublisher applicationEventPublisher;
+
+  @Override
+  public PickupRequest requestPickup(RequestPickupCommand command) {
+    PickupRequest pickupRequest =
+        storePickupRequestPort.storePickupRequest(command.toPickupRequest());
+    applicationEventPublisher.publishEvent(new PickupRequestSubmittedEvent(pickupRequest));
+    return pickupRequest;
+  }
+}

--- a/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/Driver.java
+++ b/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/Driver.java
@@ -1,12 +1,14 @@
 package com.giwankim.taxiservice.core.domain.domain;
 
 import java.net.URL;
+
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class Driver {
   private final DriverId id;
+  private final DriverStatus status;
   private final Vehicle vehicle;
   private final String name;
   private final String phoneNumber;
@@ -16,12 +18,14 @@ public class Driver {
   @Builder
   public Driver(
       DriverId id,
+      DriverStatus status,
       Vehicle vehicle,
       String name,
       String phoneNumber,
       URL profilePicture,
       Location location) {
     this.id = id;
+    this.status = status;
     this.vehicle = vehicle;
     this.name = name;
     this.phoneNumber = phoneNumber;
@@ -29,5 +33,6 @@ public class Driver {
     this.location = location;
   }
 
-  public record DriverId(Long value) {}
+  public record DriverId(Long value) {
+  }
 }

--- a/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/Driver.java
+++ b/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/Driver.java
@@ -1,0 +1,33 @@
+package com.giwankim.taxiservice.core.domain.domain;
+
+import java.net.URL;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Driver {
+  private final DriverId id;
+  private final Vehicle vehicle;
+  private final String name;
+  private final String phoneNumber;
+  private final URL profilePicture;
+  private final Location location;
+
+  @Builder
+  public Driver(
+      DriverId id,
+      Vehicle vehicle,
+      String name,
+      String phoneNumber,
+      URL profilePicture,
+      Location location) {
+    this.id = id;
+    this.vehicle = vehicle;
+    this.name = name;
+    this.phoneNumber = phoneNumber;
+    this.profilePicture = profilePicture;
+    this.location = location;
+  }
+
+  public record DriverId(Long value) {}
+}

--- a/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/Driver.java
+++ b/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/Driver.java
@@ -1,7 +1,6 @@
 package com.giwankim.taxiservice.core.domain.domain;
 
 import java.net.URL;
-
 import lombok.Builder;
 import lombok.Getter;
 
@@ -33,6 +32,5 @@ public class Driver {
     this.location = location;
   }
 
-  public record DriverId(Long value) {
-  }
+  public record DriverId(Long value) {}
 }

--- a/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/DriverStatus.java
+++ b/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/DriverStatus.java
@@ -2,8 +2,5 @@ package com.giwankim.taxiservice.core.domain.domain;
 
 public enum DriverStatus {
   OFFLINE,
-  AVAILABLE,
-  IN_ROUTE_TO_PASSENGER,
-  TRIP_IN_PROGRESS,
-  TRIP_COMPLETED
+  ONLINE
 }

--- a/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/MatchingStatus.java
+++ b/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/MatchingStatus.java
@@ -1,0 +1,7 @@
+package com.giwankim.taxiservice.core.domain.domain;
+
+public enum MatchingStatus {
+  MATCHING,
+  MATCHED,
+  MATCHING_FAILED
+}

--- a/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/Passenger.java
+++ b/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/Passenger.java
@@ -1,0 +1,22 @@
+package com.giwankim.taxiservice.core.domain.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Passenger {
+  private final PassengerId id;
+  private final String username;
+  private final String password;
+  private final String phoneNumber;
+
+  @Builder
+  public Passenger(PassengerId id, String username, String password, String phoneNumber) {
+    this.id = id;
+    this.username = username;
+    this.password = password;
+    this.phoneNumber = phoneNumber;
+  }
+
+  public record PassengerId(Long value) {}
+}

--- a/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/PickupRequest.java
+++ b/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/PickupRequest.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 
 @Getter
 public class PickupRequest {
-  private final RequestId requestId;
+  private final RequestId id;
+  private final MatchingStatus status;
   private final Passenger passenger;
   private final Location pickup;
   private final Location dropoff;
@@ -13,17 +14,19 @@ public class PickupRequest {
 
   @Builder
   public PickupRequest(
-      RequestId requestId,
+      RequestId id,
+      MatchingStatus status,
       Passenger passenger,
       Location pickup,
       Location dropoff,
       TaxiType taxiType) {
-    this.requestId = requestId;
+    this.id = id;
+    this.status = status;
     this.passenger = passenger;
     this.pickup = pickup;
     this.dropoff = dropoff;
     this.taxiType = taxiType;
   }
 
-  public record RequestId(String requestId) {}
+  public record RequestId(String value) {}
 }

--- a/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/PickupRequest.java
+++ b/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/PickupRequest.java
@@ -1,0 +1,29 @@
+package com.giwankim.taxiservice.core.domain.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PickupRequest {
+  private final RequestId requestId;
+  private final Passenger passenger;
+  private final Location pickup;
+  private final Location dropoff;
+  private final TaxiType taxiType;
+
+  @Builder
+  public PickupRequest(
+      RequestId requestId,
+      Passenger passenger,
+      Location pickup,
+      Location dropoff,
+      TaxiType taxiType) {
+    this.requestId = requestId;
+    this.passenger = passenger;
+    this.pickup = pickup;
+    this.dropoff = dropoff;
+    this.taxiType = taxiType;
+  }
+
+  public record RequestId(String requestId) {}
+}

--- a/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/PickupRequest.java
+++ b/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/PickupRequest.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 public class PickupRequest {
   private final RequestId id;
-  private final MatchingStatus status;
+  private final PickupRequestStatus status;
   private final Passenger passenger;
   private final Location pickup;
   private final Location dropoff;
@@ -15,7 +15,7 @@ public class PickupRequest {
   @Builder
   public PickupRequest(
       RequestId id,
-      MatchingStatus status,
+      PickupRequestStatus status,
       Passenger passenger,
       Location pickup,
       Location dropoff,
@@ -26,6 +26,10 @@ public class PickupRequest {
     this.pickup = pickup;
     this.dropoff = dropoff;
     this.taxiType = taxiType;
+  }
+
+  public PickupRequest(Passenger passenger, Location pickup, Location dropoff, TaxiType taxiType) {
+    this(null, PickupRequestStatus.SUBMITTED, passenger, pickup, dropoff, taxiType);
   }
 
   public record RequestId(String value) {}

--- a/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/PickupRequestStatus.java
+++ b/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/PickupRequestStatus.java
@@ -1,6 +1,7 @@
 package com.giwankim.taxiservice.core.domain.domain;
 
-public enum MatchingStatus {
+public enum PickupRequestStatus {
+  SUBMITTED,
   MATCHING,
   MATCHED,
   MATCHING_FAILED

--- a/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/Trip.java
+++ b/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/Trip.java
@@ -1,0 +1,16 @@
+package com.giwankim.taxiservice.core.domain.domain;
+
+import lombok.Getter;
+
+@Getter
+public class Trip {
+  private TripId id;
+  private TripStatus status;
+  private Driver driver;
+  private Passenger passenger;
+  private Vehicle vehicle;
+  private Location pickup;
+  private Location dropoff;
+
+  public record TripId(Long value) {}
+}

--- a/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/TripStatus.java
+++ b/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/TripStatus.java
@@ -1,11 +1,12 @@
 package com.giwankim.taxiservice.core.domain.domain;
 
 public enum TripStatus {
+  MATCHING,
   MATCHED,
+  MATCHING_FAILED,
   PICKED_UP,
   IN_PROGRESS,
-  PAID,
   DROPPED_OFF,
-  COMPLETED,
+  PAID,
   CANCELLED
 }

--- a/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/Vehicle.java
+++ b/core/core-domain/src/main/java/com/giwankim/taxiservice/core/domain/domain/Vehicle.java
@@ -1,0 +1,18 @@
+package com.giwankim.taxiservice.core.domain.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Vehicle {
+  private final String make;
+  private final String model;
+  private final String licensePlate;
+
+  @Builder
+  public Vehicle(String make, String model, String licensePlate) {
+    this.make = make;
+    this.model = model;
+    this.licensePlate = licensePlate;
+  }
+}

--- a/core/core-domain/src/test/java/com/giwankim/taxiservice/core/domain/application/service/GetTripEstimatesServiceTest.java
+++ b/core/core-domain/src/test/java/com/giwankim/taxiservice/core/domain/application/service/GetTripEstimatesServiceTest.java
@@ -9,6 +9,8 @@ import com.giwankim.taxiservice.core.domain.application.port.in.TripEstimates;
 import com.giwankim.taxiservice.core.domain.application.port.out.LoadBaseFarePort;
 import com.giwankim.taxiservice.core.domain.application.port.out.LoadDirectionsPort;
 import com.giwankim.taxiservice.core.domain.domain.*;
+import com.giwankim.taxiservice.core.domain.domain.KRWMoney;
+import com.giwankim.taxiservice.core.domain.domain.Location;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 

--- a/core/core-domain/src/test/java/com/giwankim/taxiservice/core/domain/application/service/RequestPickupServiceTest.java
+++ b/core/core-domain/src/test/java/com/giwankim/taxiservice/core/domain/application/service/RequestPickupServiceTest.java
@@ -1,0 +1,65 @@
+package com.giwankim.taxiservice.core.domain.application.service;
+
+import static com.giwankim.taxiservice.domain.Fixtures.aPickupRequest;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import com.giwankim.taxiservice.core.domain.application.port.in.RequestPickupCommand;
+import com.giwankim.taxiservice.core.domain.application.port.out.StorePickupRequestPort;
+import com.giwankim.taxiservice.core.domain.domain.PickupRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class RequestPickupServiceTest {
+  @Mock private StorePickupRequestPort storePickupRequestPort;
+
+  @Mock ApplicationEventPublisher applicationEventPublisher;
+
+  @InjectMocks private RequestPickupService requestPickupService;
+
+  @Test
+  @DisplayName("배차 요청을 저장한다.")
+  void should_persist_request_to_redis() {
+    PickupRequest pickupRequest = aPickupRequest().build();
+    given(storePickupRequestPort.storePickupRequest(any(PickupRequest.class)))
+        .willReturn(pickupRequest);
+
+    RequestPickupCommand command =
+        new RequestPickupCommand(
+            pickupRequest.getPassenger(),
+            pickupRequest.getPickup(),
+            pickupRequest.getDropoff(),
+            pickupRequest.getTaxiType());
+    requestPickupService.requestPickup(command);
+
+    then(storePickupRequestPort).should(times(1)).storePickupRequest(any(PickupRequest.class));
+  }
+
+  @Test
+  @DisplayName("배차 요청 이벤트를 발행한다.")
+  void should_publish_event() {
+    PickupRequest pickupRequest = aPickupRequest().build();
+    given(storePickupRequestPort.storePickupRequest(any(PickupRequest.class)))
+        .willReturn(pickupRequest);
+
+    RequestPickupCommand command =
+        new RequestPickupCommand(
+            pickupRequest.getPassenger(),
+            pickupRequest.getPickup(),
+            pickupRequest.getDropoff(),
+            pickupRequest.getTaxiType());
+    requestPickupService.requestPickup(command);
+
+    then(applicationEventPublisher)
+        .should(times(1))
+        .publishEvent(new PickupRequestSubmittedEvent(pickupRequest));
+  }
+}

--- a/tests/test-data/src/main/java/com/giwankim/taxiservice/domain/Fixtures.java
+++ b/tests/test-data/src/main/java/com/giwankim/taxiservice/domain/Fixtures.java
@@ -4,7 +4,11 @@ import com.giwankim.taxiservice.core.domain.application.port.in.TripEstimates;
 import com.giwankim.taxiservice.core.domain.application.port.in.TripEstimates.TripEstimatesBuilder;
 import com.giwankim.taxiservice.core.domain.domain.*;
 import com.giwankim.taxiservice.core.domain.domain.Directions.DirectionsBuilder;
+import com.giwankim.taxiservice.core.domain.domain.KRWMoney;
+import com.giwankim.taxiservice.core.domain.domain.Location;
 import com.giwankim.taxiservice.core.domain.domain.Location.LocationBuilder;
+import com.giwankim.taxiservice.core.domain.domain.Passenger.PassengerBuilder;
+import com.giwankim.taxiservice.core.domain.domain.PickupRequest.PickupRequestBuilder;
 import java.util.Arrays;
 
 public class Fixtures {
@@ -45,5 +49,23 @@ public class Fixtures {
                 TripEstimate.of(TaxiType.REGULAR, baseFare, directions),
                 TripEstimate.of(TaxiType.DELUXE, baseFare, directions),
                 TripEstimate.of(TaxiType.JUMBO, baseFare, directions)));
+  }
+
+  public static PassengerBuilder aPassenger() {
+    return Passenger.builder()
+        .id(new Passenger.PassengerId(1L))
+        .username("홍길동")
+        .password("secret-password")
+        .phoneNumber("01012345678");
+  }
+
+  public static PickupRequestBuilder aPickupRequest() {
+    return PickupRequest.builder()
+        .id(new PickupRequest.RequestId("806776b0-446f-455b-9eb1-739ab088a244"))
+        .status(PickupRequestStatus.SUBMITTED)
+        .passenger(aPassenger().build())
+        .pickup(anOrigin().build())
+        .dropoff(aDestination().build())
+        .taxiType(TaxiType.REGULAR);
   }
 }


### PR DESCRIPTION
배차 요청 처리에 필요한 도메인 모델들을 추가했습니다.

기본적으로 변경되어야 하는 속성들도 우선은 `final`로 하고 상태 변경을 일으켜야할 메서드가 추가되면서 변경 가능하게 수정할 계획입니다.

우선 레디스로 TTL을 걸고 요청을 저장하고 매칭 로직은 `ApplicationEvent`를 통해서 비동기로 처리하는 설계를 해보았습니다.

설계 리뷰와 사이즈 조절을 위해서 PR을 하게 되었고 해당하는 out-port 구현체 빈이 없는 상태로 리뷰 요청드립니다.